### PR TITLE
Fix missing API typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx cap sync
 * [`showHealthConnectInPlayStore()`](#showhealthconnectinplaystore)
 * [`queryAggregated(...)`](#queryaggregated)
 * [`queryWorkouts(...)`](#queryworkouts)
+* [`queryLatestSample(...)`](#querylatestsample)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -208,6 +209,23 @@ Query workouts
 --------------------
 
 
+### queryLatestSample(...)
+
+```typescript
+queryLatestSample(options: LatestSampleRequest) => Promise<LatestSampleResponse>
+```
+
+Query the latest single sample for the provided data type
+
+| Param         | Type                                                                | Description                               |
+| ------------- | ------------------------------------------------------------------- | ----------------------------------------- |
+| **`options`** | <code><a href="#latestsamplerequest">LatestSampleRequest</a></code> | options containing the data type to query |
+
+**Returns:** <code>Promise&lt;<a href="#latestsampleresponse">LatestSampleResponse</a>&gt;</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -243,12 +261,12 @@ Query workouts
 
 #### QueryAggregatedRequest
 
-| Prop            | Type                               |
-| --------------- | ---------------------------------- |
-| **`startDate`** | <code>string</code>                |
-| **`endDate`**   | <code>string</code>                |
-| **`dataType`**  | <code>'steps' \| 'calories'</code> |
-| **`bucket`**    | <code>string</code>                |
+| Prop            | Type                                                       |
+| --------------- | ---------------------------------------------------------- |
+| **`startDate`** | <code>string</code>                                        |
+| **`endDate`**   | <code>string</code>                                        |
+| **`dataType`**  | <code>'steps' \| 'active-calories' \| 'mindfulness'</code> |
+| **`bucket`**    | <code>string</code>                                        |
 
 
 #### QueryWorkoutResponse
@@ -269,6 +287,7 @@ Query workouts
 | **`id`**             | <code>string</code>            |
 | **`duration`**       | <code>number</code>            |
 | **`distance`**       | <code>number</code>            |
+| **`steps`**          | <code>number</code>            |
 | **`calories`**       | <code>number</code>            |
 | **`sourceBundleId`** | <code>string</code>            |
 | **`route`**          | <code>RouteSample[]</code>     |
@@ -301,6 +320,25 @@ Query workouts
 | **`endDate`**          | <code>string</code>  |
 | **`includeHeartRate`** | <code>boolean</code> |
 | **`includeRoute`**     | <code>boolean</code> |
+| **`includeSteps`**     | <code>boolean</code> |
+
+
+#### LatestSampleResponse
+
+| Prop            | Type                |
+| --------------- | ------------------- |
+| **`value`**     | <code>number</code> |
+| **`timestamp`** | <code>string</code> |
+| **`startDate`** | <code>string</code> |
+| **`endDate`**   | <code>string</code> |
+| **`unit`**      | <code>string</code> |
+
+
+#### LatestSampleRequest
+
+| Prop           | Type                                             |
+| -------------- | ------------------------------------------------ |
+| **`dataType`** | <code>'steps' \| 'heart-rate' \| 'weight'</code> |
 
 
 ### Type Aliases
@@ -308,6 +346,6 @@ Query workouts
 
 #### HealthPermission
 
-<code>'READ_STEPS' | 'READ_WORKOUTS' | 'READ_CALORIES' | 'READ_DISTANCE' | 'READ_HEART_RATE' | 'READ_ROUTE'</code>
+<code>'READ_STEPS' | 'READ_WORKOUTS' | 'READ_ACTIVE_CALORIES' | 'READ_TOTAL_CALORIES' | 'READ_DISTANCE' | 'READ_WEIGHT' | 'READ_HEART_RATE' | 'READ_ROUTE' | 'READ_MINDFULNESS'</code>
 
 </docgen-api>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -55,6 +55,12 @@ export interface HealthPlugin {
    * @param request
    */
   queryWorkouts(request: QueryWorkoutRequest): Promise<QueryWorkoutResponse>;
+
+  /**
+   * Query the latest single sample for the provided data type
+   * @param options options containing the data type to query
+   */
+  queryLatestSample(options: LatestSampleRequest): Promise<LatestSampleResponse>;
 }
 
 export declare type HealthPermission =
@@ -63,6 +69,7 @@ export declare type HealthPermission =
   | 'READ_ACTIVE_CALORIES'
   | 'READ_TOTAL_CALORIES'
   | 'READ_DISTANCE'
+  | 'READ_WEIGHT'
   | 'READ_HEART_RATE'
   | 'READ_ROUTE'
   | 'READ_MINDFULNESS';
@@ -129,4 +136,16 @@ export interface AggregatedSample {
   startDate: string;
   endDate: string;
   value: number;
+}
+
+export interface LatestSampleRequest {
+  dataType: 'heart-rate' | 'weight' | 'steps';
+}
+
+export interface LatestSampleResponse {
+  value: number;
+  timestamp?: string;
+  startDate?: string;
+  endDate?: string;
+  unit?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ import type { HealthPlugin } from './definitions';
 
 export const Health = registerPlugin<HealthPlugin>('HealthPlugin', {});
 
-export * from './definitions'
+export * from './definitions';


### PR DESCRIPTION
## Summary
- expose `queryLatestSample` in type definitions
- add `READ_WEIGHT` permission constant
- generate updated docs

## Testing
- `npm run fmt`
- `npm run build`
- `npm run docgen`


------
https://chatgpt.com/codex/tasks/task_e_6849cd877b54832aab4087153ea56730