### PR TITLE
Fix PermissionResponse type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npx cap sync
 
 * Make sure your app id has the 'HealthKit' entitlement when this plugin is installed (see iOS dev center).
 * Also, make sure your app and App Store description comply with the Apple review guidelines.
-* There are two keys to be added to the info.plist file: NSHealthShareUsageDescription and NSHealthUpdateUsageDescription. 
+* There are two keys to be added to the info.plist file: NSHealthShareUsageDescription and NSHealthUpdateUsageDescription.
 
 ### Android
 
@@ -340,7 +340,7 @@ Query latest steps sample
 
 | Prop              | Type                                       |
 | ----------------- | ------------------------------------------ |
-| **`permissions`** | <code>{ [key: string]: boolean; }[]</code> |
+| **`permissions`** | <code>Record<HealthPermission, boolean></code> |
 
 
 #### PermissionsRequest

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -102,7 +102,7 @@ export interface PermissionsRequest {
 }
 
 export interface PermissionResponse {
-  permissions: { [key: string]: boolean }[];
+  permissions: Record<HealthPermission, boolean>;
 }
 
 export interface QueryWorkoutRequest {


### PR DESCRIPTION
The documented type says it’s an array of objects with strings as keys and booleans as values, but the Android Studio logs show it’s actually an object with `HealthPermission` as keys.:

<img width="335" height="27" alt="image" src="https://github.com/user-attachments/assets/0ce6c4cb-c0af-4843-9efe-5b3e983a1daa" />

Updated the type (and docs) to match the actual data structure.